### PR TITLE
Modernize pivotal product scripts to Python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
-Steps to run the project:
-```bash
+# Pivotal Product Tools
 
-brew install python3
-brew install direnv
+Modern Python 3.12 scripts for analyzing Pivotal product files.
 
-pip3 install virtualenv
-virtualenv -p python3 venv
+## Quick Start
 
-direnv allow
+1.  **Install**:
+    ```bash
+    brew install python3
+    python3 -m venv venv && source venv/bin/activate
+    pip install -r requirements.txt
+    ```
 
+2.  **Run**:
+    ```bash
+    python3 weight.py --file-path path/to/product.pivotal
+    ```
 
-python3 weight.py --help
-```
+## Development
+
+*   **Test**: `pytest`
+*   **Lint/Format**: `ruff check --fix .` / `ruff format .`
+*   **Type Check**: `mypy .`

--- a/pivotal_product.py
+++ b/pivotal_product.py
@@ -1,115 +1,93 @@
-import os.path
 import tarfile
 import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
 
 import yaml
 
 
+@dataclass
 class BoshRelease:
-    @staticmethod
-    def from_manifest(manifest, file_size, compress_size):
-        return BoshRelease(
-            manifest["name"],
-            manifest["version"],
+    name: str
+    version: str
+    file_size: int | None = None
+    compress_size: int | None = None
+
+    @classmethod
+    def from_manifest(
+        cls, manifest: dict[str, Any], file_size: int, compress_size: int
+    ) -> "BoshRelease":
+        return cls(
+            name=manifest["name"],
+            version=manifest["version"],
             file_size=file_size,
             compress_size=compress_size,
         )
 
-    def __init__(self, name, version, file_size=None, compress_size=None):
-        self._name = name
-        self._version = version
-        self._file_size = file_size
-        self._compress_size = compress_size
 
-    @property
-    def name(self):
-        return self._name
+@dataclass
+class PivotalProduct:
+    name: str
+    version: str
+    file_size: int | None = None
+    releases: list[BoshRelease] = field(default_factory=list)
 
-    @property
-    def version(self):
-        return self._version
+    @classmethod
+    def from_metadata(
+        cls, metadata: dict[str, Any], file_size: int
+    ) -> "PivotalProduct":
+        return cls(
+            name=metadata["name"],
+            version=metadata["product_version"],
+            file_size=file_size,
+        )
 
-    @property
-    def file_size(self):
-        return self._file_size
-
-    @property
-    def compress_size(self):
-        return self._compress_size
-
-    def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+    def add_release(self, release: BoshRelease) -> None:
+        self.releases.append(release)
 
 
-def _find_manifest(release_tar):
+def _find_manifest(release_tar: tarfile.TarFile) -> dict[str, Any]:
     for release_file in release_tar:
         if release_file.name.endswith("release.MF"):
             release_manifest_file = release_tar.extractfile(release_file)
-            return yaml.load(release_manifest_file.read())
+            if release_manifest_file:
+                return cast(
+                    dict[str, Any], yaml.safe_load(release_manifest_file.read())
+                )
     raise LookupError("couldn't find 'release.MF' file")
 
 
-def parse_product(product_file_path):
-    if not os.path.isfile(product_file_path):
-        raise ValueError("{} is not a file".format(product_file_path))
+def parse_product(product_file_path: str | Path) -> PivotalProduct:
+    path = Path(product_file_path)
+    if not path.is_file():
+        raise ValueError(f"{path} is not a file")
 
-    if not zipfile.is_zipfile(product_file_path):
-        raise ValueError("{} is not a zip file".format(product_file_path))
+    if not zipfile.is_zipfile(path):
+        raise ValueError(f"{path} is not a zip file")
 
-    product_file_size = os.path.getsize(product_file_path)
+    product_file_size = path.stat().st_size
 
-    product_zip = zipfile.ZipFile(product_file_path)
-    metadata_zipinfo = product_zip.getinfo("metadata/metadata.yml")
-    metadata_file = product_zip.open(metadata_zipinfo)
-    metadata = yaml.load(metadata_file)
+    with zipfile.ZipFile(path) as product_zip:
+        metadata_zipinfo = product_zip.getinfo("metadata/metadata.yml")
+        with product_zip.open(metadata_zipinfo) as metadata_file:
+            metadata = cast(dict[str, Any], yaml.safe_load(metadata_file))
 
-    pp = PivotalProduct.from_metadata(metadata, product_file_size)
+        pp = PivotalProduct.from_metadata(metadata, product_file_size)
 
-    releases = [
-        pf for pf in product_zip.infolist() if pf.filename.startswith("releases")
-    ]
+        releases = [
+            pf for pf in product_zip.infolist() if pf.filename.startswith("releases")
+        ]
 
-    for release in releases:
-        release_tar_file = product_zip.open(release)
-        release_tar = tarfile.open(mode="r:gz", fileobj=release_tar_file)
+        for release in releases:
+            with product_zip.open(release) as release_tar_file:
+                with tarfile.open(mode="r:gz", fileobj=release_tar_file) as release_tar:
+                    release_manifest = _find_manifest(release_tar)
 
-        release_manifest = _find_manifest(release_tar)
-
-        pp.add_release(
-            BoshRelease.from_manifest(
-                release_manifest, release.file_size, release.compress_size
-            )
-        )
+                    pp.add_release(
+                        BoshRelease.from_manifest(
+                            release_manifest, release.file_size, release.compress_size
+                        )
+                    )
 
     return pp
-
-
-class PivotalProduct:
-    @staticmethod
-    def from_metadata(metadata, file_size):
-        return PivotalProduct(metadata["name"], metadata["product_version"], file_size)
-
-    def __init__(self, name, version, file_size=None):
-        self._name = name
-        self._version = version
-        self._file_size = file_size
-        self._releases = []
-
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def version(self):
-        return self._version
-
-    @property
-    def file_size(self):
-        return self._file_size
-
-    @property
-    def releases(self):
-        return self._releases
-
-    def add_release(self, release):
-        self._releases.append(release)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = [
+    ".",
+]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+ignore = []
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-certifi==2023.7.22
-chardet==3.0.4
-datadog==0.26.0
-decorator==4.3.2
-idna==2.8
-requests==2.31.0
-simplejson==3.16.0
-urllib3==1.26.18
+beeprint
+PyYAML
+pytest
+ruff
+mypy
+types-PyYAML

--- a/test_pivotal_product.py
+++ b/test_pivotal_product.py
@@ -1,95 +1,91 @@
+import io
 import tarfile
 import tempfile
-import unittest
-from zipfile import ZipFile, ZIP_STORED
+import zipfile
+from pathlib import Path
+from typing import Generator
 
+import pytest
 import yaml
 
-from pivotal_product import PivotalProduct, BoshRelease, parse_product
+from pivotal_product import BoshRelease, parse_product
 
 
-class TestBoshRelease(unittest.TestCase):
-    def test_properties_only_needed(self):
+class TestBoshRelease:
+    def test_properties_only_needed(self) -> None:
         br = BoshRelease("random-name", "random-version")
 
-        self.assertEqual("random-name", br.name, "name doesn't match")
-        self.assertEqual("random-version", br.version, "version doesn't match")
-        self.assertIsNone(br.file_size, "file size is not None")
-        self.assertIsNone(br.compress_size, "compress size is not None")
+        assert br.name == "random-name"
+        assert br.version == "random-version"
+        assert br.file_size is None
+        assert br.compress_size is None
 
-    def test_properties_all(self):
+    def test_properties_all(self) -> None:
         br = BoshRelease("random-name", "random-version", 1234, 5678)
 
-        self.assertEqual("random-name", br.name, "name doesn't match")
-        self.assertEqual("random-version", br.version, "version doesn't match")
-        self.assertEqual(1234, br.file_size, "file_size doesn't match")
-        self.assertEqual(5678, br.compress_size, "compress_size doesn't match")
+        assert br.name == "random-name"
+        assert br.version == "random-version"
+        assert br.file_size == 1234
+        assert br.compress_size == 5678
 
-    def test_from_manifest(self):
+    def test_from_manifest(self) -> None:
         manifest = {"name": "name-from-manifest", "version": "version-from-manifest"}
         br = BoshRelease.from_manifest(manifest, 1234, 5678)
 
-        self.assertEqual("name-from-manifest", br.name, "name doesn't match")
-        self.assertEqual("version-from-manifest", br.version, "version doesn't match")
-        self.assertEqual(1234, br.file_size, "file_size doesn't match")
-        self.assertEqual(5678, br.compress_size, "compress_size doesn't match")
+        assert br.name == "name-from-manifest"
+        assert br.version == "version-from-manifest"
+        assert br.file_size == 1234
+        assert br.compress_size == 5678
 
 
-class TestPivotalProduct(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls._product_file_path = tempfile.NamedTemporaryFile(delete=False).name
+@pytest.fixture
+def product_file() -> Generator[Path, None, None]:
+    product_metadata = {"product_version": "1.2.3.4.5", "name": "the-product"}
 
-        product_metadata = {"product_version": "1.2.3.4.5", "name": "the-product"}
+    release1_metadata = {"name": "release-1-name", "version": "release-1-version"}
+    release2_metadata = {"name": "release-2-name", "version": "release-2-version"}
 
-        release1_metadata = {"name": "release-1-name", "version": "release-1-version"}
-        release2_metadata = {"name": "release-2-name", "version": "release-2-version"}
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        pivotal_file = temp_path / "product.pivotal"
 
-        with ZipFile(cls._product_file_path, "w", compression=ZIP_STORED) as temp_zip:
-            temp_zip.writestr(
+        with zipfile.ZipFile(pivotal_file, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr(
                 "metadata/metadata.yml",
                 yaml.dump(product_metadata, default_flow_style=False),
             )
 
-            with tarfile.open("release-1.tgz", "w:gz") as tar:
-                with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
-                    fp.write(yaml.dump(release1_metadata, default_flow_style=False))
-                tar.add(fp.name, arcname="release.MF")
-            temp_zip.write(tar.name, arcname="releases/release-1.tgz")
+            for i, meta in enumerate([release1_metadata, release2_metadata], 1):
+                tgz_name = f"release-{i}.tgz"
+                tgz_path = temp_path / tgz_name
 
-            with tarfile.open("release-2.tgz", "w:gz") as tar:
-                with tempfile.NamedTemporaryFile(mode="w", delete=False) as fp:
-                    fp.write(yaml.dump(release2_metadata, default_flow_style=False))
-                tar.add(fp.name, arcname="./release.MF")
-            temp_zip.write(tar.name, arcname="releases/release-2.tgz")
+                with tarfile.open(tgz_path, "w:gz") as tar:
+                    manifest_content = yaml.dump(meta, default_flow_style=False).encode(
+                        "utf-8"
+                    )
+                    ti = tarfile.TarInfo("release.MF")
+                    ti.size = len(manifest_content)
+                    tar.addfile(ti, io.BytesIO(manifest_content))
 
-        print("[setUp] created file", cls._product_file_path)
+                zf.write(tgz_path, arcname=f"releases/{tgz_name}")
 
-    @classmethod
-    def tearDownClass(cls):
-        pass
-        # os.remove(cls._product_file_path)
-
-    def setUp(self):
-        self.pivotal_product = parse_product(self.__class__._product_file_path)
-
-    def test_get_product_version(self):
-        self.assertEqual(
-            "1.2.3.4.5", self.pivotal_product.version, "product version doesn't match"
-        )
-
-    def test_get_product_name(self):
-        self.assertEqual(
-            "the-product", self.pivotal_product.name, "product name doesn't match"
-        )
-
-    def test_get_releases(self):
-        self.assertEqual("release-1-name", self.pivotal_product.releases[0].name)
-        self.assertEqual("release-1-version", self.pivotal_product.releases[0].version)
-
-        self.assertEqual("release-2-name", self.pivotal_product.releases[1].name)
-        self.assertEqual("release-2-version", self.pivotal_product.releases[1].version)
+        yield pivotal_file
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_parse_product(product_file: Path) -> None:
+    pp = parse_product(product_file)
+
+    assert pp.version == "1.2.3.4.5"
+    assert pp.name == "the-product"
+    assert len(pp.releases) == 2
+
+    # Verify releases are sorted or order preserved?
+    # ZipFile.infolist() order depends on insertion order usually.
+    # I inserted release-1 then release-2.
+    # But checking by name is safer if order is not guaranteed.
+
+    r1 = next(r for r in pp.releases if r.name == "release-1-name")
+    assert r1.version == "release-1-version"
+
+    r2 = next(r for r in pp.releases if r.name == "release-2-name")
+    assert r2.version == "release-2-version"

--- a/weight.py
+++ b/weight.py
@@ -1,18 +1,32 @@
 import argparse
-import os
+from pathlib import Path
 
 from beeprint import pp
 
 import pivotal_product
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--file-path", help="path to your .pivotal file")
 
-args = parser.parse_args()
-print(args)
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file-path", help="path to your .pivotal file", required=True)
 
-product_size = os.path.getsize(args.file_path)
+    # Use parse_known_args to handle extra arguments passed by CI/CD (e.g. --api-key)
+    # without crashing, even if we don't use them yet.
+    args, unknown = parser.parse_known_args()
 
-product = pivotal_product.parse_product(args.file_path)
+    if unknown:
+        print(f"Ignoring unknown arguments: {unknown}")
 
-pp(product)
+    file_path = Path(args.file_path)
+    print(f"Processing file: {file_path}")
+
+    try:
+        product = pivotal_product.parse_product(file_path)
+        pp(product)
+    except Exception as e:
+        print(f"Error: {e}")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Modernized the codebase to Python 3.12 standards. 

Key changes include:
- Refactoring `pivotal_product.py` to use `dataclasses` and `pathlib`, improving code readability and type safety.
- Updating `weight.py` to use `argparse` with `parse_known_args` to support existing CI pipeline arguments without implementing logic for them, preventing crashes.
- Migrating tests to `pytest` with fixture-based setup.
- Enforcing code quality with `ruff` and `mypy` configurations in `pyproject.toml`.
- Cleaning up dependencies in `requirements.txt` and removing unused packages.
- Addressing security by replacing `yaml.load` with `yaml.safe_load`.
- Updated `README.md` to be concise, focusing on quick start and development commands.

---
*PR created automatically by Jules for task [16144156679615863061](https://jules.google.com/task/16144156679615863061) started by @vlad-stoian*